### PR TITLE
Decodable json fixes

### DIFF
--- a/NimbleCodeChallenge.xcodeproj/project.pbxproj
+++ b/NimbleCodeChallenge.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		1E05D9E288998500D72D6989 /* Pods_NimbleCodeChallenge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90F4022EDA010721167B78A1 /* Pods_NimbleCodeChallenge.framework */; };
 		4D2DF67A7B444784CFCDFF2B /* Pods_NimbleCodeChallenge_NimbleCodeChallengeUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93BED338FC8947D5A4A1107B /* Pods_NimbleCodeChallenge_NimbleCodeChallengeUITests.framework */; };
 		FA258B0F23F8859E00138060 /* ImageResolutionable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA258B0E23F8859E00138060 /* ImageResolutionable.swift */; };
+		FA258B1323F8A15700138060 /* PageControlModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA258B1223F8A15700138060 /* PageControlModel.swift */; };
+		FA258B1523F8AE2400138060 /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA258B1423F8AE2400138060 /* UserModel.swift */; };
+		FA258B1723F8B88400138060 /* JSONCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA258B1623F8B88400138060 /* JSONCodable.swift */; };
 		FA2BD57723EA362A0089ACE9 /* CachedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2BD57623EA362A0089ACE9 /* CachedImageView.swift */; };
 		FAA5ECF123EB4B4A00BD87D9 /* NetworkStatusVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA5ECF023EB4B4A00BD87D9 /* NetworkStatusVC.swift */; };
 		FAA5ECFA23EBC5D900BD87D9 /* NimbleCodeChallengeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB7E68423E5DF400007D438 /* NimbleCodeChallengeTests.swift */; };
@@ -59,6 +62,9 @@
 		9AB48888EEF30B54E9727027 /* Pods-NimbleCodeChallenge-NimbleCodeChallengeUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleCodeChallenge-NimbleCodeChallengeUITests.debug.xcconfig"; path = "Target Support Files/Pods-NimbleCodeChallenge-NimbleCodeChallengeUITests/Pods-NimbleCodeChallenge-NimbleCodeChallengeUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		DDC77E78B7EDC8ADB41598ED /* Pods-NimbleCodeChallenge.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbleCodeChallenge.release.xcconfig"; path = "Target Support Files/Pods-NimbleCodeChallenge/Pods-NimbleCodeChallenge.release.xcconfig"; sourceTree = "<group>"; };
 		FA258B0E23F8859E00138060 /* ImageResolutionable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResolutionable.swift; sourceTree = "<group>"; };
+		FA258B1223F8A15700138060 /* PageControlModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageControlModel.swift; sourceTree = "<group>"; };
+		FA258B1423F8AE2400138060 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
+		FA258B1623F8B88400138060 /* JSONCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCodable.swift; sourceTree = "<group>"; };
 		FA2BD57623EA362A0089ACE9 /* CachedImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedImageView.swift; sourceTree = "<group>"; };
 		FAA5ECF023EB4B4A00BD87D9 /* NetworkStatusVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusVC.swift; sourceTree = "<group>"; };
 		FAB7E66A23E5DF390007D438 /* NimbleCodeChallenge.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NimbleCodeChallenge.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -140,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				FA258B0E23F8859E00138060 /* ImageResolutionable.swift */,
+				FA258B1623F8B88400138060 /* JSONCodable.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -236,6 +243,8 @@
 			children = (
 				FAD0D97323E5F72500FFBE58 /* OathModel.swift */,
 				FAFB964C23E8AE9C00AD7FBC /* SurveyModel.swift */,
+				FA258B1223F8A15700138060 /* PageControlModel.swift */,
+				FA258B1423F8AE2400138060 /* UserModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -515,11 +524,14 @@
 				FAFB965223E8EBE700AD7FBC /* Extensions.swift in Sources */,
 				FA2BD57723EA362A0089ACE9 /* CachedImageView.swift in Sources */,
 				FA258B0F23F8859E00138060 /* ImageResolutionable.swift in Sources */,
+				FA258B1723F8B88400138060 /* JSONCodable.swift in Sources */,
 				FAE1364323F5EA34001E72F2 /* PageVCManager.swift in Sources */,
 				FAD0D97423E5F72500FFBE58 /* OathModel.swift in Sources */,
 				FAB7E6A523E5E6720007D438 /* MainPageVM.swift in Sources */,
 				FAB7E66E23E5DF390007D438 /* AppDelegate.swift in Sources */,
+				FA258B1323F8A15700138060 /* PageControlModel.swift in Sources */,
 				FAFB965023E8B8F800AD7FBC /* APIClient.swift in Sources */,
+				FA258B1523F8AE2400138060 /* UserModel.swift in Sources */,
 				FAFB964D23E8AE9C00AD7FBC /* SurveyModel.swift in Sources */,
 				FAB7E69E23E5E2360007D438 /* MainPageVC.swift in Sources */,
 				FAB7E67023E5DF390007D438 /* SceneDelegate.swift in Sources */,

--- a/NimbleCodeChallenge/Extension&Utils/Extensions.swift
+++ b/NimbleCodeChallenge/Extension&Utils/Extensions.swift
@@ -129,3 +129,16 @@ extension UIView {
         }
     }
 }
+
+public extension Data {
+    /// Decode this data into a value
+    func decoded<T: Decodable>(as type: T.Type = T.self) -> T? {
+        do {
+            return try JSONDecoder().decode(T.self, from: self)
+        } catch _ {
+            
+        }
+        return nil
+    }
+}
+

--- a/NimbleCodeChallenge/Models/OathModel.swift
+++ b/NimbleCodeChallenge/Models/OathModel.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct OathModel: Codable {
+struct OathModel: JSONCodable {
     let accessToken, tokenType: String
     let expiresIn, createdAt: Int64
     

--- a/NimbleCodeChallenge/Models/PageControlModel.swift
+++ b/NimbleCodeChallenge/Models/PageControlModel.swift
@@ -1,0 +1,25 @@
+//
+//  PageControlModel.swift
+//  NimbleCodeChallenge
+//
+//  Created by MacBook Pro on 16/02/2020.
+//  Copyright © 2020 MacBook Pro. All rights reserved.
+//
+
+import Foundation
+
+struct PageControlModel: JSONCodable {
+    var perPage: Int = 5
+    var page: Int
+    
+    
+    enum CodingKeys: String, CodingKey {
+        case page
+        case perPage = "per_page"
+    }
+    
+    init(with page: Int) {
+        self.page = page
+    }
+    
+}

--- a/NimbleCodeChallenge/Models/SurveyModel.swift
+++ b/NimbleCodeChallenge/Models/SurveyModel.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-struct SurveyModel: Codable, ImageResolutionable {
+struct SurveyModel: JSONCodable, ImageResolutionable {
+    
     let id: String
     let title: String
     let description: String
@@ -24,6 +25,7 @@ struct SurveyModel: Codable, ImageResolutionable {
         case theme
         
     }
+    
 }
 
 struct Theme: Codable {

--- a/NimbleCodeChallenge/Models/UserModel.swift
+++ b/NimbleCodeChallenge/Models/UserModel.swift
@@ -1,0 +1,21 @@
+//
+//  UserModel.swift
+//  NimbleCodeChallenge
+//
+//  Created by MacBook Pro on 16/02/2020.
+//  Copyright © 2020 MacBook Pro. All rights reserved.
+//
+
+import Foundation
+
+struct UserModel: JSONCodable {
+    var grantType: String
+    var userName: String
+    var password: String
+    
+    enum CodingKeys: String, CodingKey {
+        case grantType = "grant_type"
+        case userName = "username"
+        case password
+    }
+}

--- a/NimbleCodeChallenge/NetworkManager/APIClient.swift
+++ b/NimbleCodeChallenge/NetworkManager/APIClient.swift
@@ -25,8 +25,8 @@ enum NetworkingErrors: Error {
 }
 
 class APIClient {
-    static let sharedManager = APIClient()
     
+    static let sharedManager = APIClient()
     // pod KeychainSwift object to easy read write into keychain
     private let keychain = KeychainSwift()
     
@@ -92,14 +92,6 @@ class APIClient {
         , apiEncoding: ParameterEncoding = JSONEncoding.default
         , withBlock completion : @escaping (Data?, NetworkingErrors?) -> Void){
         
-        if isPrint {
-            print("*****************URL***********************\n")
-            print("URL:- \(url)\n")
-            print("Parameter:-\(String(describing: parameter))\n")
-            print("MethodType:- \(requestMethod.rawValue)\n")
-            print("headers:-\(String(describing: apiHeaders))\n")
-            print("*****************End***********************\n")
-        }
         var encodingScheme: ParameterEncoding = apiEncoding
         if requestMethod == .get {
             encodingScheme = URLEncoding.default
@@ -141,10 +133,14 @@ class APIClient {
     /// - Parameter completion: callback
     private func getAuthToken(_ completion: @escaping (OathModel?)->Void) {
         
-        let params = ["grant_type": "password",
-                      "username": "carlos@nimbl3.com",
-                      "password": "antikera"]
+        let user = UserModel(grantType: "password",
+                                      userName: "carlos@nimbl3.com",
+                                      password: "antikera")
         
+        guard let params = user.toDictionary() else {
+            return
+        }
+    
         let apiHeaders = [
             "Content-Type": "application/json",
             "Accept": "application/json",
@@ -161,7 +157,6 @@ class APIClient {
                     authModel = try decoder.decode(OathModel.self, from: responseData)
                     // save auth data into keychain
                     strongSelf.keychain.set(responseData, forKey: "auth_data")
-                    
                 }
                 
             }catch let error {

--- a/NimbleCodeChallenge/NetworkManager/APIClient.swift
+++ b/NimbleCodeChallenge/NetworkManager/APIClient.swift
@@ -50,9 +50,6 @@ class APIClient {
             "Accept": "application/json"
         ]
         
-        
-        
-        
         if let authModel = self.retriveAuthModel(),  authModel.isValidAccessToken() {
             apiHeaders["Authorization"] = "Bearer \(authModel.accessToken)"
             self.almofireJSONrequest(strURL: url, parameter: param, apiHeaders: apiHeaders) { [weak self] (responseData, error) in
@@ -100,11 +97,8 @@ class APIClient {
         Alamofire.request(url, method: requestMethod, parameters: parameter, encoding: encodingScheme, headers: apiHeaders).responseJSON(completionHandler: { (response) in
             
             switch(response.result) {
-            case .success(let JSON):
-                if isPrint {
-                    print(JSON)
-                }
-                
+            case .success( _):
+              
                 DispatchQueue.main.async {
                     if response.response!.statusCode == 200 {
                         //do things
@@ -116,10 +110,6 @@ class APIClient {
                 }
                 
             case .failure(let error):
-                if isPrint {
-                    print(error.localizedDescription)
-                }
-                
                 DispatchQueue.main.async {
                     completion(nil, .returnedError(error))
                 }
@@ -151,18 +141,14 @@ class APIClient {
                 return
             }
             var authModel: OathModel?
-            do{
-                let decoder = JSONDecoder()
-                if let responseData = responseData {
-                    authModel = try decoder.decode(OathModel.self, from: responseData)
-                    // save auth data into keychain
-                    strongSelf.keychain.set(responseData, forKey: "auth_data")
-                }
-                
-            }catch let error {
-                print(error.localizedDescription)
+
+            if let responseData = responseData,
+                let oathModel = responseData.decoded(as: OathModel.self) {
+                // save auth data into keychain
+                authModel = oathModel
+                strongSelf.keychain.set(responseData, forKey: "auth_data")
             }
-            
+
             completion(authModel)
         }
         

--- a/NimbleCodeChallenge/Protocols/JSONCodable.swift
+++ b/NimbleCodeChallenge/Protocols/JSONCodable.swift
@@ -1,0 +1,29 @@
+//
+//  Serializable.swift
+//  NimbleCodeChallenge
+//
+//  Created by MacBook Pro on 16/02/2020.
+//  Copyright © 2020 MacBook Pro. All rights reserved.
+//
+
+import Foundation
+
+
+protocol JSONCodable: Codable {
+    typealias JSON = [String : Any]
+    func toDictionary() -> JSON?
+}
+ 
+extension JSONCodable {
+    
+    func toDictionary() -> JSON? {
+        // Encode the data
+        if let jsonData = try? JSONEncoder().encode(self),
+            // Create a dictionary from the data
+            let dict = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? JSON {
+            return dict
+        }
+        return nil
+    }
+    
+}

--- a/NimbleCodeChallenge/ViewModels/MainPageVM.swift
+++ b/NimbleCodeChallenge/ViewModels/MainPageVM.swift
@@ -37,8 +37,7 @@ class MainPageVM {
                 return
             }
             if let responseData = responseData {
-                let decoder = JSONDecoder()
-                if let serverData = try? decoder.decode([SurveyModel].self, from: responseData), serverData.count > 0 {
+                if let serverData = responseData.decoded(as: [SurveyModel].self), serverData.count > 0 {
                     if isRefresh {
                         strongSelf.surveysData.removeAll()
                     }

--- a/NimbleCodeChallenge/ViewModels/MainPageVM.swift
+++ b/NimbleCodeChallenge/ViewModels/MainPageVM.swift
@@ -23,11 +23,7 @@ class MainPageVM {
         
         self.pageController = PageControlModel(with: self.nextPageNumber(with: isRefresh))
         
-        guard let params = self.pageController.toDictionary() else {
-            return
-        }
-        
-        APIClient.sharedManager.makeApiRequest(requestMethod: .get, strURL: surveysURL,parameter: params) { [weak self] (responseData, error) in
+        APIClient.sharedManager.makeApiRequest(requestMethod: .get, strURL: surveysURL,parameter: self.pageController) { [weak self] (responseData, error) in
             
             guard let strongSelf = self else {
                 return

--- a/NimbleCodeChallengeTests/NimbleCodeChallengeTests.swift
+++ b/NimbleCodeChallengeTests/NimbleCodeChallengeTests.swift
@@ -32,7 +32,7 @@ class NimbleCodeChallengeTests: XCTestCase {
     var dumySurveyGenerator: DummySurveys!
     var authModel: OathModel!
     var pageManager: PageVCManager!
-    var perPageLimit: Int!
+    var pageController: PageControlModel!
     var newloadDataindex: Int!
     var newdataLoadIndex: Int!
     
@@ -40,9 +40,11 @@ class NimbleCodeChallengeTests: XCTestCase {
         self.viewModel = MainPageVM()
         self.pageManager = PageVCManager()
         self.dumySurveyGenerator = DummySurveys()
-        self.perPageLimit = self.viewModel.perPageLimit
+        
         let dummySurveys = self.dumySurveyGenerator.createDummySurveys(size: 10)
         self.viewModel.surveysData.append(contentsOf: dummySurveys)
+
+        self.pageController = PageControlModel(with: 4)
         self.newdataLoadIndex = self.viewModel.surveysData.count - self.viewModel.loadDataThreshold
         self.authModel = OathModel(accessToken: "", tokenType: "", expiresIn: 7200, createdAt: Int64(Date().timeIntervalSince1970))
         
@@ -60,15 +62,18 @@ class NimbleCodeChallengeTests: XCTestCase {
     
     
     func testnextPageNumberWhen10loadedSurveys() {
-        XCTAssertEqual(viewModel.nextPageNumber(), (10 / self.perPageLimit))
+        XCTAssertEqual(viewModel.nextPageNumber(), (10 / self.pageController.perPage))
     }
     
     
-    func testloadnewdatawhenbelowthreshold()  {        XCTAssertFalse(self.viewModel.isLoadNewDataRequired(index: self.newdataLoadIndex - 1))
+    func testloadnewdatawhenbelowthreshold()  {
+        
+        XCTAssertFalse(self.viewModel.isLoadNewDataRequired(index: self.newdataLoadIndex - 1))
     }
     
     func testloadnewdatawhenabovethreshold()  {
-        XCTAssertTrue(self.viewModel.isLoadNewDataRequired(index: self.newdataLoadIndex))
+        
+        XCTAssertTrue(self.viewModel.isLoadNewDataRequired(index: self.newdataLoadIndex + 1))
     }
     
     func testSrollForwardAtLastPage() {


### PR DESCRIPTION
**Goal**

- Implement Codable instead of dictionaries to send as param in API calls
- generic decoder extension


**Implementation details**

- added `JSONCodable` protocol which can encode Object to Dictionary. which later we can send to APIClient as param.

- JSONCodable.toDictioanry() moved to APIClient to make it more generic.
 